### PR TITLE
Add Dotenv in development environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,13 +22,16 @@ group :test do
   gem "capybara"
   gem "rails-controller-testing"
   gem "factory_bot_rails"
-  gem "dotenv-rails"
   gem "rspec_junit_formatter"
 end
 
 group :development do
   gem "web-console"
   gem "listen", "~> 3.0.5"
+end
+
+group :development, :test do
+  gem "dotenv-rails"
 end
 
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]


### PR DESCRIPTION
Dotenv is also used when developing, so it should be added to the development environment too.